### PR TITLE
chore:#20 elastic search 관련 yml 설정

### DIFF
--- a/MENDITTZO-Backend/src/main/resources/application.yml
+++ b/MENDITTZO-Backend/src/main/resources/application.yml
@@ -11,6 +11,8 @@ spring:
   elasticsearch:
     rest:
       uris: http://localhost:9200
+      username: "elastic" # 아이디 elastic
+      password: "elastic"  #비밀번호 elastic
 
   config:
     import: "classpath:API-KEY.yml"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,17 @@
+version: '3'
+services:
+  elasticsearch:
+    image: elasticsearch:8.15.3  # 버전 8.15.3
+    container_name: elasticsearch
+    environment:
+      - discovery.type=single-node
+      - ELASTIC_PASSWORD=elastic # 비밀번호 elastic 아이디도 동일
+    ports:
+      - "9200:9200"
+      - "9300:9300"
+    networks:
+      - elastic-net
+
+networks:
+  elastic-net:
+    driver: bridge


### PR DESCRIPTION
elastic search 관련 yml 설정 파일입니다. 

현재 elastic search 파일은 도커 허브에서 가져옴으로써 로컬에 elastic search를 다운 받지 않아도 되게 만들었습니다.
elastic search 다운로드 버전은 8.15.3 버전입니다. 
yml에 설치하도록 작성해서 문제가 없을 것으로 판단된다만, 에러 로그에 이미지가 없다고 하면
터미널에 "docker pull elasticsearch:8.15.3" 
작성하셔서 다운 받으시면 되겠습니다.

yml 파일에 들어간 내용중 아이디와 비밀번호는 elastic으로 통일했습니다.
port는 기본 9200 port를 사용해서 필요시 바꿔서 사용하시면 됩니다.

디비와의 연동 문제는 아직 해결 중이며 해결 완료 후 pr 다시 올리겠습니다. 