### PR TITLE
Chore/elastic/#22 log stash 연동 

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,8 +1,0 @@
-# Default ignored files
-/shelf/
-/workspace.xml
-# Editor-based HTTP Client requests
-/httpRequests/
-# Datasource local storage ignored files
-/dataSources/
-/dataSources.local.xml

--- a/MENDITTZO-Backend/.gitignore
+++ b/MENDITTZO-Backend/.gitignore
@@ -32,47 +32,47 @@ out/
 /nbbuild/
 /dist/
 /nbdist/HELP.md
-        .gradle
-        build/
-        !gradle/wrapper/gradle-wrapper.jar
-        !**/src/main/**/build/
-        !**/src/test/**/build/
+.gradle
+build/
+!gradle/wrapper/gradle-wrapper.jar
+!**/src/main/**/build/
+!**/src/test/**/build/
 
-        ### STS ###
-        .apt_generated
-        .classpath
-        .factorypath
-        .project
-        .settings
-        .springBeans
-        .sts4-cache
-        bin/
-        !**/src/main/**/bin/
-        !**/src/test/**/bin/
+### STS ###
+.apt_generated
+.classpath
+.factorypath
+.project
+.settings
+.springBeans
+.sts4-cache
+bin/
+!**/src/main/**/bin/
+!**/src/test/**/bin/
 
-        ### IntelliJ IDEA ###
-        .idea
-        *.iws
-        *.iml
-        *.ipr
-        .env
-        out/
-        !**/src/main/**/out/
-        !**/src/test/**/out/
+### IntelliJ IDEA ###
+.idea
+*.iws
+*.iml
+*.ipr
+.env
+out/
+!**/src/main/**/out/
+!**/src/test/**/out/
 
-        ### NetBeans ###
-        /nbproject/private/
-        /nbbuild/
-        /dist/
-        /nbdist/
-        /.nb-gradle/
+### NetBeans ###
+/nbproject/private/
+/nbbuild/
+/dist/
+/nbdist/
+/.nb-gradle/
 
-        ### VS Code ###
-        .vscode/
-        API-KEY.yml
+### VS Code ###
+.vscode/
+API-KEY.yml
 
-        ### 기타 설정 파일 ###
-        .idea/
+### 기타 설정 파일 ###
+.idea/
 /.nb-gradle/
 
 ### VS Code ###

--- a/MENDITTZO-Backend/.gitignore
+++ b/MENDITTZO-Backend/.gitignore
@@ -22,6 +22,7 @@ bin/
 *.iws
 *.iml
 *.ipr
+.env
 out/
 !**/src/main/**/out/
 !**/src/test/**/out/
@@ -30,7 +31,48 @@ out/
 /nbproject/private/
 /nbbuild/
 /dist/
-/nbdist/
+/nbdist/HELP.md
+        .gradle
+        build/
+        !gradle/wrapper/gradle-wrapper.jar
+        !**/src/main/**/build/
+        !**/src/test/**/build/
+
+        ### STS ###
+        .apt_generated
+        .classpath
+        .factorypath
+        .project
+        .settings
+        .springBeans
+        .sts4-cache
+        bin/
+        !**/src/main/**/bin/
+        !**/src/test/**/bin/
+
+        ### IntelliJ IDEA ###
+        .idea
+        *.iws
+        *.iml
+        *.ipr
+        .env
+        out/
+        !**/src/main/**/out/
+        !**/src/test/**/out/
+
+        ### NetBeans ###
+        /nbproject/private/
+        /nbbuild/
+        /dist/
+        /nbdist/
+        /.nb-gradle/
+
+        ### VS Code ###
+        .vscode/
+        API-KEY.yml
+
+        ### 기타 설정 파일 ###
+        .idea/
 /.nb-gradle/
 
 ### VS Code ###

--- a/MENDITTZO-Backend/logstash/logstash.conf
+++ b/MENDITTZO-Backend/logstash/logstash.conf
@@ -1,0 +1,22 @@
+input {
+  jdbc {
+    jdbc_connection_string => "jdbc:mariadb://localhost:3306/debook_db"
+    jdbc_user => "${JDBC_USER}"
+    jdbc_password => "${JDBC_PASSWORD}"
+    jdbc_driver_library => "/path/to/mariadb-java-client.jar"  # MariaDB JDBC 드라이버 경로로 추정됨 정확하지 않음
+    jdbc_driver_class => "org.mariadb.jdbc.Driver"
+    statement => "SELECT * FROM book"  # book 테이블에서 가져오도록 매핑
+    schedule => "* * * * *"  # 매 분마다 동기화
+  }
+}
+
+output {
+  elasticsearch {
+    hosts => ["https://localhost:9200"]
+    user => "elastic"
+    password => "elastic"
+    index => "books" # 저장할 인덱스 이름
+    ssl => true # https 사용하게 만드는 설정
+    ssl_certificate_verification => false # 서버 인증서 검증을 활성화 할건지 여부 대충 false로 두면 된다 추후 발전사항으로 true로 두어 보안성을 높여서 만들면 됨
+  }
+}

--- a/MENDITTZO-Backend/src/main/java/com/mendittzo/elastic/query/dto/ElasticDTO.java
+++ b/MENDITTZO-Backend/src/main/java/com/mendittzo/elastic/query/dto/ElasticDTO.java
@@ -1,6 +1,7 @@
 package com.mendittzo.elastic.query.dto;
 
 import org.springframework.data.annotation.Id;
+import org.springframework.data.elasticsearch.annotations.Document;
 import org.springframework.data.elasticsearch.annotations.Field;
 import org.springframework.data.elasticsearch.annotations.FieldType;
 import lombok.Getter;
@@ -10,6 +11,8 @@ import lombok.ToString;
 @Getter
 @Setter
 @ToString
+//@Document(indexName = "books")
+// 엘라스틱 서치와 인덱싱 테스트 할때 작성한 어노테이션 로그 스테시 작업 이후 삭제 예정
 public class ElasticDTO {
 
     @Id

--- a/MENDITTZO-Backend/src/main/resources/application.yml
+++ b/MENDITTZO-Backend/src/main/resources/application.yml
@@ -23,3 +23,20 @@ spring:
       naming:
         physical-strategy:
           org.hibernate.boot.model.naming.CamelCaseToUnderscoresNamingStrategy
+
+  logstash:
+    image: logstash:8.15.3
+    container_name: logstash
+    volumes:
+      - ./logstash/logstash.conf:/usr/share/logstash/pipeline/logstash.conf # 이 부분이 맞는지는 다시 한번 확인 및 검증이 필요함
+      - /usr/local/lib/mariadb-java-client.jar:/usr/share/logstash/mariadb-java-client.jar # 이 부분이 맞는지는 다시 한번 확인 및 검증이 필요함
+    environment:
+      - LS_JAVA_OPTS="-Xmx1g -Xms1g"
+      - JDBC_USER=${db.username}
+      - JDBC_PASSWORD=${db.password}
+    command: logstash -f /usr/share/logstash/pipeline/logstash.conf
+    depends_on:
+      - elasticsearch
+      - mariadb
+    networks:
+      - elastic-net

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,17 +1,56 @@
 version: '3'
+
 services:
+  # Elasticsearch 서비스 설정
   elasticsearch:
-    image: elasticsearch:8.15.3  # 버전 8.15.3
+    image: elasticsearch:8.15.3  # Elasticsearch 버전 8.15.3
     container_name: elasticsearch
     environment:
-      - discovery.type=single-node
-      - ELASTIC_PASSWORD=elastic # 비밀번호 elastic 아이디도 동일
+      - discovery.type=single-node  # 클러스터 설정 (단일 노드 모드)
+      - ELASTIC_PASSWORD=elastic  # Elasticsearch 기본 비밀번호 설정
     ports:
-      - "9200:9200"
-      - "9300:9300"
+      - "9200:9200"  # HTTP 포트
+      - "9300:9300"  # TCP 포트
     networks:
       - elastic-net
 
+  # MariaDB 서비스 설정 이 부분은 어차피 나중에 도커로 담을거긴 한데 일단 이게 맞는지 모르겠지만 넣어햐 하니까 넣긴 함
+  mariadb:
+    image: mariadb:latest  # 최신 MariaDB 이미지 사용
+    container_name: mariadb
+    environment:
+      - MYSQL_ROOT_PASSWORD=${MARIADB_ROOT_PASSWORD}  # MariaDB root 비밀번호 설정 mysql이어도 상관 없다고 함
+      - MYSQL_DATABASE=debook_db     # 기본 데이터베이스 이름 설정
+      - MYSQL_USER=${MARIADB_USER}      # 사용자 이름 (env 파일에서 불러옴)
+      - MYSQL_PASSWORD=${MARIADB_PASSWORD}  # 비밀번호 (env 파일에서 불러옴)
+    ports:
+      - "3306:3306"  # 3306 포트 사용
+    env_file:
+      - .env  # .env 파일에서 환경 변수 불러오기
+    networks:
+      - elastic-net
+
+  # Logstash 서비스 설정
+  logstash:
+    image: logstash:8.15.3  # Logstash 버전 8.15.3
+    container_name: logstash
+    volumes:
+      - ./logstash/logstash.conf:/usr/share/logstash/pipeline/logstash.conf  # Logstash 설정 파일 마운트 이 부분이 맞는지 확인 필요
+      - /path/to/mariadb-java-client.jar:/usr/share/logstash/mariadb-java-client.jar  # MariaDB JDBC 드라이버 마운트 이 부분이 맞는지 확인 필요
+    environment:
+      - LS_JAVA_OPTS="-Xmx1g -Xms1g"  # Logstash 메모리 설정
+      - JDBC_USER=${MARIADB_USER}  # 사용자 이름 (env 파일에서 불러옴)
+      - JDBC_PASSWORD=${MARIADB_PASSWORD}  # 비밀번호 (env 파일에서 불러옴)
+    command: logstash -f /usr/share/logstash/pipeline/logstash.conf  # Logstash 명령어 # 이것도 정확한지 확인 필요함 뭔가 애매해 있는거 그대로 쓰긴 햇는데
+    depends_on:
+      - elasticsearch  # Logstash는 Elasticsearch 시작 후에 실행
+      - mariadb        # Logstash는 MariaDB 시작 후에 실행
+    env_file:
+      - .env  # .env 파일에서 환경 변수 불러오기
+    networks:
+      - elastic-net
+
+# 네트워크 설정
 networks:
   elastic-net:
-    driver: bridge
+    driver: bridge  # 브리지 네트워크 사용


### PR DESCRIPTION
log stash 구현부 
env 파일은 도커에서 필요한 마리아 디비 아이디와 비밀번호를 담고 있습니다.
yml 파일에 한번에 하고자 하였으나 스프링부트 파일이 아니어서 우선적으로 처리를 못한다고 하여 부득이 하게 
env 파일로 구성했습니다. 

아직 기본적인 틀만 만들어두고 자세한 부분은 더 수정 보완이 필요합니다. 
현재까지는 기본적인 뼈대와 틀은 잡아두었고 주소와 버전에 대한 상호 작용을 검토해야합니다. 

로그 스태시까지 구성이 완료되면 엘라스틱 서치에서 조회하는 정보를 마리아 디비에서 꺼내오는 pipeline작업까지 완료가 되는 부분입니다. 

추가적으로 주석도 더 자섹하게 달았으니 보시면서 이해가 되지 않는 부분을 많이 줄였을거라고 생각합니다. 
질문생기시면 바로 남겨주시면 답변 드리겠습니다.