### PR TITLE
Feat/#24 access, refresh 토큰 생성

### DIFF
--- a/MENDITTZO-Backend/build.gradle
+++ b/MENDITTZO-Backend/build.gradle
@@ -30,6 +30,10 @@ dependencies {
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0'
     // 소셜 로그인 시 필요한 서버 -> 외부 API HTTP 요청 처리
     implementation 'org.springframework.boot:spring-boot-starter-webflux:3.3.5'
+    // jwt
+    implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
+    runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-web'

--- a/MENDITTZO-Backend/src/main/java/com/mendittzo/auth/query/application/controller/KakaoLoginController.java
+++ b/MENDITTZO-Backend/src/main/java/com/mendittzo/auth/query/application/controller/KakaoLoginController.java
@@ -1,5 +1,6 @@
 package com.mendittzo.auth.query.application.controller;
 
+import com.mendittzo.auth.query.application.dto.DebookTokenDTO;
 import com.mendittzo.auth.query.application.dto.KakaoLoginUrlResponseDTO;
 import com.mendittzo.auth.query.application.dto.KakaoTokenResponseDTO;
 import com.mendittzo.auth.query.application.dto.UserResponseDTO;
@@ -21,6 +22,7 @@ public class KakaoLoginController {
     public ResponseEntity<KakaoLoginUrlResponseDTO> getKakaoLoginPage() {
 
         KakaoLoginUrlResponseDTO loginUrlResponse = kakaoAuthService.getKakaoLoginUrl();
+        // todo: success code 등등 넘기게 바꾸기
         return new ResponseEntity<>(loginUrlResponse, HttpStatus.OK);
     }
 
@@ -31,9 +33,10 @@ public class KakaoLoginController {
     // 3. 액세스 토큰으로 카카오 고유 사용자 id 요청
     // 4. 카카오 고유 사용자 id 로 DB 에서 서비스 사용자 정보 조회
     @GetMapping("/auth/callback")
-    public ResponseEntity<UserResponseDTO> getAuthorizationCode(@RequestParam String code) {
+    public ResponseEntity<DebookTokenDTO> getAuthorizationCode(@RequestParam String code) {
 
-        UserResponseDTO userResponse = kakaoAuthService.kakaoLogin(code);
-        return new ResponseEntity<>(userResponse, HttpStatus.OK);
+        DebookTokenDTO token = kakaoAuthService.kakaoLogin(code);
+        // todo: success code 등등 넘기게 바꾸기
+        return new ResponseEntity<>(token, HttpStatus.OK);
     }
 }

--- a/MENDITTZO-Backend/src/main/java/com/mendittzo/auth/query/application/dto/DebookTokenDTO.java
+++ b/MENDITTZO-Backend/src/main/java/com/mendittzo/auth/query/application/dto/DebookTokenDTO.java
@@ -10,6 +10,7 @@ import lombok.Setter;
 @Setter
 @NoArgsConstructor
 public class DebookTokenDTO {
+
     private String accessToken;
     private Long accessTokenExpiresIn;
     private String refreshToken;

--- a/MENDITTZO-Backend/src/main/java/com/mendittzo/auth/query/application/dto/DebookTokenDTO.java
+++ b/MENDITTZO-Backend/src/main/java/com/mendittzo/auth/query/application/dto/DebookTokenDTO.java
@@ -1,0 +1,30 @@
+package com.mendittzo.auth.query.application.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.mendittzo.auth.query.domain.aggregate.Token;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+// 서비스 자체 토큰 - 클라이언트로 전송용
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class DebookTokenDTO {
+    private String accessToken;
+    private Long accessTokenExpiresIn;
+    private String refreshToken;
+    private Long refreshTokenExpiresIn;
+
+    public DebookTokenDTO(String accessToken, Long accessTokenExpiresIn, String refreshToken, Long refreshTokenExpiresIn) {
+        this.accessToken = accessToken;
+        this.accessTokenExpiresIn = accessTokenExpiresIn;
+        this.refreshToken = refreshToken;
+        this.refreshTokenExpiresIn = refreshTokenExpiresIn;
+    }
+
+    public static DebookTokenDTO create(String accessToken, Long accessTokenExpiresIn, String refreshToken, Long refreshTokenExpiresIn) {
+        return new DebookTokenDTO(accessToken, accessTokenExpiresIn, refreshToken, refreshTokenExpiresIn);
+    }
+}

--- a/MENDITTZO-Backend/src/main/java/com/mendittzo/auth/query/application/dto/DebookTokenDTO.java
+++ b/MENDITTZO-Backend/src/main/java/com/mendittzo/auth/query/application/dto/DebookTokenDTO.java
@@ -1,7 +1,5 @@
 package com.mendittzo.auth.query.application.dto;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
-import com.mendittzo.auth.query.domain.aggregate.Token;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;

--- a/MENDITTZO-Backend/src/main/java/com/mendittzo/auth/query/application/dto/TokenCreateRequestDTO.java
+++ b/MENDITTZO-Backend/src/main/java/com/mendittzo/auth/query/application/dto/TokenCreateRequestDTO.java
@@ -10,6 +10,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class TokenCreateRequestDTO {
+
     private Long tokenId;
 
     @NotNull

--- a/MENDITTZO-Backend/src/main/java/com/mendittzo/auth/query/application/dto/TokenCreateRequestDTO.java
+++ b/MENDITTZO-Backend/src/main/java/com/mendittzo/auth/query/application/dto/TokenCreateRequestDTO.java
@@ -1,0 +1,29 @@
+package com.mendittzo.auth.query.application.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class TokenCreateRequestDTO {
+    private Long tokenId;
+
+    @NotNull
+    private Long loginId;
+
+    @NotNull
+    private String accessToken;
+
+    @NotNull
+    private Long accessTokenExpireDatetime;
+
+    @NotNull
+    private String refreshToken;
+
+    @NotBlank
+    private Long refreshTokenExpireDatetime;
+
+}

--- a/MENDITTZO-Backend/src/main/java/com/mendittzo/auth/query/application/dto/TokenCreateRequestDTO.java
+++ b/MENDITTZO-Backend/src/main/java/com/mendittzo/auth/query/application/dto/TokenCreateRequestDTO.java
@@ -5,6 +5,7 @@ import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor

--- a/MENDITTZO-Backend/src/main/java/com/mendittzo/auth/query/application/dto/UserResponseDTO.java
+++ b/MENDITTZO-Backend/src/main/java/com/mendittzo/auth/query/application/dto/UserResponseDTO.java
@@ -20,6 +20,7 @@ public class UserResponseDTO {
     private Long loginId;
 
     public UserResponseDTO(User user) {
+
         this.userId = user.getUserId();
         this.email = user.getEmail();
         this.nickname = user.getNickname();

--- a/MENDITTZO-Backend/src/main/java/com/mendittzo/auth/query/application/service/KakaoAuthService.java
+++ b/MENDITTZO-Backend/src/main/java/com/mendittzo/auth/query/application/service/KakaoAuthService.java
@@ -182,11 +182,9 @@ public class KakaoAuthService {
         );
 
         createToken(tokenRequest);
-
         return token;
     }
 
-    @Transactional
     public void createToken(TokenCreateRequestDTO tokenRequest) {
 
         Token newToken = TokenMapper.toEntity(tokenRequest);

--- a/MENDITTZO-Backend/src/main/java/com/mendittzo/auth/query/application/service/KakaoAuthService.java
+++ b/MENDITTZO-Backend/src/main/java/com/mendittzo/auth/query/application/service/KakaoAuthService.java
@@ -171,7 +171,7 @@ public class KakaoAuthService {
         // 4. access token, refresh token 생성
         DebookTokenDTO token = jwtUtil.generateToken(user);
 
-         // 5. DB(redis 로 바꾸기 전 임시 mariaDB)에 토큰 저장
+        // 5. DB(redis 로 바꾸기 전 임시 mariaDB)에 토큰 저장
         TokenCreateRequestDTO tokenRequest = new TokenCreateRequestDTO(
                 null,
                 user.getLoginId(),

--- a/MENDITTZO-Backend/src/main/java/com/mendittzo/auth/query/application/service/KakaoAuthService.java
+++ b/MENDITTZO-Backend/src/main/java/com/mendittzo/auth/query/application/service/KakaoAuthService.java
@@ -1,6 +1,10 @@
 package com.mendittzo.auth.query.application.service;
 
 import com.mendittzo.auth.query.application.dto.*;
+import com.mendittzo.auth.query.domain.aggregate.Token;
+import com.mendittzo.auth.query.domain.repository.TokenRepository;
+import com.mendittzo.auth.query.mapper.TokenMapper;
+import com.mendittzo.security.util.JwtUtil;
 import com.mendittzo.user.command.application.dto.UserCreateRequestDTO;
 import com.mendittzo.user.command.application.service.UserCommandService;
 import com.mendittzo.user.command.domain.aggregate.User;
@@ -27,6 +31,8 @@ public class KakaoAuthService {
 
     private final UserRepository userRepository;
     private final UserCommandService userCommandService;
+    private final TokenRepository tokenRepository;
+    private final JwtUtil jwtUtil;
 
     // 필수 쿼리 파라미터
     // (1) client_id : REST API 키
@@ -118,7 +124,6 @@ public class KakaoAuthService {
         User existsUser = userRepository.findByLoginIdAndAuthProvider(
                 kakaoUserInfo.getLoginId(), "KAKAO");
 
-
         // DB에 사용자가 없으면 생성
         if (existsUser == null) {
             UserCreateRequestDTO userRequestDTO = new UserCreateRequestDTO(
@@ -145,7 +150,7 @@ public class KakaoAuthService {
     }
 
     @Transactional
-    public UserResponseDTO kakaoLogin(String code) {
+    public DebookTokenDTO kakaoLogin(String code) {
 
         // 1. 인증 코드로 액세스 토큰 요청
         String accessToken = requestAccessToken(code);
@@ -163,6 +168,29 @@ public class KakaoAuthService {
         // 3. 카카오 고유 사용자 id 로 DB 에서 서비스 사용자 조회 및 저장
         User user = findOrCreateUser(kakaoUserInfo);
 
-        return new UserResponseDTO(user);
+        // 4. access token, refresh token 생성
+        DebookTokenDTO token = jwtUtil.generateToken(user);
+
+         // 5. DB(redis 로 바꾸기 전 임시 mariaDB)에 토큰 저장
+        TokenCreateRequestDTO tokenRequest = new TokenCreateRequestDTO(
+                null,
+                user.getLoginId(),
+                token.getAccessToken(),
+                token.getAccessTokenExpiresIn(),
+                token.getRefreshToken(),
+                token.getRefreshTokenExpiresIn()
+        );
+
+        createToken(tokenRequest);
+
+        return token;
     }
+
+    @Transactional
+    public void createToken(TokenCreateRequestDTO tokenRequest) {
+
+        Token newToken = TokenMapper.toEntity(tokenRequest);
+        tokenRepository.save(newToken);
+    }
+
 }

--- a/MENDITTZO-Backend/src/main/java/com/mendittzo/auth/query/domain/aggregate/Token.java
+++ b/MENDITTZO-Backend/src/main/java/com/mendittzo/auth/query/domain/aggregate/Token.java
@@ -9,8 +9,6 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
-import java.time.LocalDateTime;
-
 @Entity
 @Table(name = "token")
 @Getter

--- a/MENDITTZO-Backend/src/main/java/com/mendittzo/auth/query/domain/aggregate/Token.java
+++ b/MENDITTZO-Backend/src/main/java/com/mendittzo/auth/query/domain/aggregate/Token.java
@@ -1,0 +1,57 @@
+package com.mendittzo.auth.query.domain.aggregate;
+
+// todo: redis 사용 전 임시로 maraiaDB 에 저장용
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "token")
+@Getter
+@EntityListeners(AuditingEntityListener.class)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Token {
+
+    @Id
+    @JsonProperty("token_id")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long tokenId;
+
+    @JsonProperty("login_id")
+    @Column(nullable = false)
+    private Long loginId;
+
+    @JsonProperty("access_token")
+    @Column(nullable = false)
+    private String accessToken;
+
+    @JsonProperty("access_token_expire_datetime")
+    @Column(nullable = false)
+    private Long accessTokenExpireDatetime;
+
+    @JsonProperty("refresh_token")
+    @Column(nullable = false)
+    private String refreshToken;
+
+    @JsonProperty("refresh_token_expire_datetime")
+    @Column(nullable = false)
+    private Long refreshTokenExpireDatetime;
+
+    public Token(Long loginId, String accessToken, Long accessTokenExpireDatetime, String refreshToken, Long refreshTokenExpireDatetime) {
+        this.loginId = loginId;
+        this.accessToken = accessToken;
+        this.accessTokenExpireDatetime = accessTokenExpireDatetime;
+        this.refreshToken = refreshToken;
+        this.refreshTokenExpireDatetime = refreshTokenExpireDatetime;
+    }
+
+    public static Token create(Long loginId, String accessToken, Long accessTokenExpireDatetime, String refreshToken, Long refreshTokenExpireDatetime) {
+        return new Token(loginId, accessToken, accessTokenExpireDatetime, refreshToken, refreshTokenExpireDatetime);
+    }
+}

--- a/MENDITTZO-Backend/src/main/java/com/mendittzo/auth/query/domain/repository/TokenRepository.java
+++ b/MENDITTZO-Backend/src/main/java/com/mendittzo/auth/query/domain/repository/TokenRepository.java
@@ -1,0 +1,7 @@
+package com.mendittzo.auth.query.domain.repository;
+
+import com.mendittzo.auth.query.domain.aggregate.Token;
+
+public interface TokenRepository {
+    Token save(Token newToken);
+}

--- a/MENDITTZO-Backend/src/main/java/com/mendittzo/auth/query/domain/repository/TokenRepository.java
+++ b/MENDITTZO-Backend/src/main/java/com/mendittzo/auth/query/domain/repository/TokenRepository.java
@@ -3,5 +3,6 @@ package com.mendittzo.auth.query.domain.repository;
 import com.mendittzo.auth.query.domain.aggregate.Token;
 
 public interface TokenRepository {
+
     Token save(Token newToken);
 }

--- a/MENDITTZO-Backend/src/main/java/com/mendittzo/auth/query/infrastructure/repository/JpaTokenRepository.java
+++ b/MENDITTZO-Backend/src/main/java/com/mendittzo/auth/query/infrastructure/repository/JpaTokenRepository.java
@@ -1,0 +1,8 @@
+package com.mendittzo.auth.query.infrastructure.repository;
+
+import com.mendittzo.auth.query.domain.aggregate.Token;
+import com.mendittzo.auth.query.domain.repository.TokenRepository;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface JpaTokenRepository extends JpaRepository<Token, Long>, TokenRepository {
+}

--- a/MENDITTZO-Backend/src/main/java/com/mendittzo/auth/query/infrastructure/repository/JpaTokenRepository.java
+++ b/MENDITTZO-Backend/src/main/java/com/mendittzo/auth/query/infrastructure/repository/JpaTokenRepository.java
@@ -5,4 +5,5 @@ import com.mendittzo.auth.query.domain.repository.TokenRepository;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface JpaTokenRepository extends JpaRepository<Token, Long>, TokenRepository {
+
 }

--- a/MENDITTZO-Backend/src/main/java/com/mendittzo/auth/query/mapper/TokenMapper.java
+++ b/MENDITTZO-Backend/src/main/java/com/mendittzo/auth/query/mapper/TokenMapper.java
@@ -4,6 +4,7 @@ import com.mendittzo.auth.query.application.dto.TokenCreateRequestDTO;
 import com.mendittzo.auth.query.domain.aggregate.Token;
 
 public class TokenMapper {
+
     public static Token toEntity(TokenCreateRequestDTO tokenRequest) {
 
         return Token.create(

--- a/MENDITTZO-Backend/src/main/java/com/mendittzo/auth/query/mapper/TokenMapper.java
+++ b/MENDITTZO-Backend/src/main/java/com/mendittzo/auth/query/mapper/TokenMapper.java
@@ -1,0 +1,18 @@
+package com.mendittzo.auth.query.mapper;
+
+import com.mendittzo.auth.query.application.dto.TokenCreateRequestDTO;
+import com.mendittzo.auth.query.domain.aggregate.Token;
+
+public class TokenMapper {
+    public static Token toEntity(TokenCreateRequestDTO tokenRequest) {
+
+        return Token.create(
+                tokenRequest.getLoginId(),
+                tokenRequest.getAccessToken(),
+                tokenRequest.getAccessTokenExpireDatetime(),
+                tokenRequest.getRefreshToken(),
+                tokenRequest.getRefreshTokenExpireDatetime()
+        );
+    }
+
+}

--- a/MENDITTZO-Backend/src/main/java/com/mendittzo/common/exception/ErrorCode.java
+++ b/MENDITTZO-Backend/src/main/java/com/mendittzo/common/exception/ErrorCode.java
@@ -9,7 +9,13 @@ import org.springframework.http.HttpStatus;
 public enum ErrorCode {
 
     // 500 에러
-    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버에러 발생");
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버에러 발생"),
+
+    // 토큰 관련 에러
+    INVALID_JWT(HttpStatus.UNAUTHORIZED, "유효하지 않은 JWT 토큰"),
+    EXPIRED_JWT(HttpStatus.UNAUTHORIZED, "만료된 JWT 토큰"),
+    UNSUPPORTED_JWT(HttpStatus.BAD_REQUEST, "지원하지 않는 JWT 토큰"),
+    EMPTY_JWT(HttpStatus.BAD_REQUEST, "빈 JWT 토큰");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/MENDITTZO-Backend/src/main/java/com/mendittzo/common/exception/ErrorCode.java
+++ b/MENDITTZO-Backend/src/main/java/com/mendittzo/common/exception/ErrorCode.java
@@ -18,7 +18,7 @@ public enum ErrorCode {
     EMPTY_JWT(HttpStatus.BAD_REQUEST, "빈 JWT 토큰"),
 
     // 400 에러
-    NOT_MATCH_FILE_EXTENSION(HttpStatus.BAD_REQUEST,"허용되지 않은 확장자입니다." ),
+    NOT_MATCH_FILE_EXTENSION(HttpStatus.BAD_REQUEST, "허용되지 않은 확장자입니다."),
 
     // 404 에러
     NOT_FOUND_USER(HttpStatus.NOT_FOUND, "유저정보를 찾을 수 없습니다."),

--- a/MENDITTZO-Backend/src/main/java/com/mendittzo/common/exception/ErrorResponse.java
+++ b/MENDITTZO-Backend/src/main/java/com/mendittzo/common/exception/ErrorResponse.java
@@ -20,7 +20,7 @@ public class ErrorResponse {
         this.code = errorCode.name();
         this.message = errorCode.getMessage();
     }
-    
+
     public static ResponseEntity<ErrorResponse> error(CustomException e) {
 
         return ResponseEntity

--- a/MENDITTZO-Backend/src/main/java/com/mendittzo/common/exception/SuccessCode.java
+++ b/MENDITTZO-Backend/src/main/java/com/mendittzo/common/exception/SuccessCode.java
@@ -9,12 +9,11 @@ import org.springframework.http.HttpStatus;
 public enum SuccessCode {
 
     // 200
-    SUCCESS(HttpStatus.OK,"OK"),
+    SUCCESS(HttpStatus.OK, "OK"),
     USER_UPDATE_SUCCESS(HttpStatus.OK, "유저 정보 수정에 성공하였습니다."),
 
     // 201
-    REPORT_CREATE_SUCCESS(HttpStatus.CREATED, "신고 등록에 성공하였습니다.")
-    ;
+    REPORT_CREATE_SUCCESS(HttpStatus.CREATED, "신고 등록에 성공하였습니다.");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/MENDITTZO-Backend/src/main/java/com/mendittzo/security/HMACKeyGenerator.java
+++ b/MENDITTZO-Backend/src/main/java/com/mendittzo/security/HMACKeyGenerator.java
@@ -7,7 +7,9 @@ import java.util.Base64;
 // JWT 검증을 위한 비밀 키 생성하는 클래스 (직접 사용 X)
 
 public class HMACKeyGenerator {
+
     public static void main(String[] args) {
+
         try {
             /* HS512를 위한 KeyGenerator 생성 */
             KeyGenerator keyGen = KeyGenerator.getInstance("HmacSHA512");

--- a/MENDITTZO-Backend/src/main/java/com/mendittzo/security/util/JwtUtil.java
+++ b/MENDITTZO-Backend/src/main/java/com/mendittzo/security/util/JwtUtil.java
@@ -1,0 +1,105 @@
+package com.mendittzo.security.util;
+
+import com.mendittzo.auth.query.application.dto.DebookTokenDTO;
+import com.mendittzo.common.exception.CustomException;
+import com.mendittzo.common.exception.ErrorCode;
+import com.mendittzo.user.command.domain.aggregate.User;
+import io.jsonwebtoken.*;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.security.Key;
+import java.util.Date;
+
+@Slf4j
+@Component
+public class JwtUtil {
+
+    private final Key secretKey;
+
+    public JwtUtil(@Value("${token.secret}") String secretKey) {
+        byte[] keyBytes = Decoders.BASE64.decode(secretKey);
+        this.secretKey = Keys.hmacShaKeyFor(keyBytes);
+    }
+
+    @Value(("${token.access_token_expiration_time}"))
+    private String accessExpirationTime;
+
+    @Value(("${token.refresh_token_expiration_time}"))
+    private String refreshExpirationTime;
+
+    // 토큰 생성하는 메소드
+    public DebookTokenDTO generateToken(User user) {
+
+        log.info("secret Key: {}", secretKey);
+        Long accessTokenExpirationTime = Long.parseLong(accessExpirationTime) * 1000L;
+        Long refreshTokenExpirationTime = Long.parseLong(refreshExpirationTime) * 1000L;
+
+        // JWT payload
+        Claims claims = Jwts.claims().setSubject(user.getNickname());   // String 타입의 식별자가 필요하므로 닉네임으로 구분
+        claims.put("socialLoginId", user.getLoginId()); // 소셜 로그인 사용자 고유 id 추가 저장
+
+        // 토큰 발급
+        String accessToken = Jwts.builder()
+                .setClaims(claims)  // payload 에 사용자 및 추가 데이터 저장
+                .setIssuedAt(new Date(System.currentTimeMillis()))   // 토큰 발행 시간
+                .setExpiration(new Date(System.currentTimeMillis() + accessTokenExpirationTime))  // 토큰 만료 시간
+                .signWith(SignatureAlgorithm.HS512, secretKey)  // 암호화 알고리즘
+                .compact();
+
+        String refreshToken = Jwts.builder()
+                .setClaims(claims)  // payload 에 사용자 및 추가 데이터 저장
+                .setIssuedAt(new Date(System.currentTimeMillis()))   // 토큰 발행 시간
+                .setExpiration(new Date(System.currentTimeMillis() + refreshTokenExpirationTime))  // 토큰 만료 시간
+                .signWith(SignatureAlgorithm.HS512, secretKey)  // 암호화 알고리즘
+                .compact();
+
+        return DebookTokenDTO.create(
+                accessToken,
+                System.currentTimeMillis() + accessTokenExpirationTime,
+                refreshToken,
+                System.currentTimeMillis() + refreshTokenExpirationTime
+        );
+    }
+
+    // 토큰 검증하는 메소드
+    public boolean validateToken(String token) {
+        try {
+            // 토큰 생성 시 사용한 키로 검증
+            Jwts.parserBuilder().setSigningKey(secretKey).build().parseClaimsJws(token);
+            return true;
+
+        } catch (io.jsonwebtoken.security.SecurityException | MalformedJwtException e) {
+
+            log.info("유효하지 않은 JWT 토큰 {}", e);
+            throw new CustomException(ErrorCode.INVALID_JWT);
+        } catch (ExpiredJwtException e) {
+
+            log.info("만료된 JWT 토큰 {}", e);
+            throw new CustomException(ErrorCode.EXPIRED_JWT);
+        } catch (UnsupportedJwtException e) {
+
+            log.info("지원하지 않는 JWT 토큰 {}", e);
+            throw new CustomException(ErrorCode.UNSUPPORTED_JWT);
+        } catch (IllegalArgumentException e) {
+
+            log.info("빈 JWT 토큰 claims {}", e);
+            throw new CustomException(ErrorCode.EMPTY_JWT);
+        }
+    }
+
+    // 토큰에서 Claims 추출하는 메소드
+    public Claims parseClaims(String token) {
+
+        return Jwts.parserBuilder().setSigningKey(secretKey).build().parseClaimsJws(token).getBody();
+    }
+
+    // 토큰에서 사용자의 소셜 로그인 고유 id 추출
+    public Long getLoginId(String token) {
+
+        return parseClaims(token).get("socialLoginId", Long.class);
+    }
+}

--- a/MENDITTZO-Backend/src/main/java/com/mendittzo/user/command/application/controller/UserCommandController.java
+++ b/MENDITTZO-Backend/src/main/java/com/mendittzo/user/command/application/controller/UserCommandController.java
@@ -5,7 +5,10 @@ import com.mendittzo.user.command.application.dto.UserUpdateDTO;
 import com.mendittzo.user.command.application.service.UserCommandService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;

--- a/MENDITTZO-Backend/src/main/java/com/mendittzo/user/command/application/dto/UserCreateRequestDTO.java
+++ b/MENDITTZO-Backend/src/main/java/com/mendittzo/user/command/application/dto/UserCreateRequestDTO.java
@@ -9,6 +9,7 @@ import java.time.LocalDateTime;
 @Getter
 @RequiredArgsConstructor
 public class UserCreateRequestDTO {
+
     private final Long userId;
     private final String email;
     private final String nickname;

--- a/MENDITTZO-Backend/src/main/java/com/mendittzo/user/command/domain/aggregate/User.java
+++ b/MENDITTZO-Backend/src/main/java/com/mendittzo/user/command/domain/aggregate/User.java
@@ -1,6 +1,5 @@
 package com.mendittzo.user.command.domain.aggregate;
 
-import com.mendittzo.user.command.application.dto.UserUpdateDTO;
 import com.mendittzo.user.query.application.dto.UserQueryResponseDTO;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
@@ -70,7 +69,7 @@ public class User {
                 .build();
     }
 
-    public void updateUser(String newNickname, String newImageUrl){
+    public void updateUser(String newNickname, String newImageUrl) {
 
         this.nickname = newNickname;
         this.profileImg = newImageUrl;

--- a/MENDITTZO-Backend/src/main/java/com/mendittzo/user/command/mapper/UserMapper.java
+++ b/MENDITTZO-Backend/src/main/java/com/mendittzo/user/command/mapper/UserMapper.java
@@ -5,8 +5,11 @@ import com.mendittzo.user.command.domain.aggregate.Status;
 import com.mendittzo.user.command.domain.aggregate.User;
 
 public class UserMapper {
+
     public static User toEntity(UserCreateRequestDTO userRequest) {
+
         return User.create(
+
                 userRequest.getUserId(),
                 userRequest.getEmail(),
                 userRequest.getNickname(),

--- a/MENDITTZO-Backend/src/main/java/com/mendittzo/user/query/application/controller/UserQueryController.java
+++ b/MENDITTZO-Backend/src/main/java/com/mendittzo/user/query/application/controller/UserQueryController.java
@@ -17,7 +17,7 @@ public class UserQueryController {
     private final UserQueryService userQueryService;
 
     @GetMapping("/{userId}")
-    public ResponseEntity<UserQueryResponseDTO> findUserInfo(@PathVariable(name = "userId") Long userId){
+    public ResponseEntity<UserQueryResponseDTO> findUserInfo(@PathVariable(name = "userId") Long userId) {
 
         UserQueryResponseDTO findUserInfo = userQueryService.findUserInfo(userId);
 

--- a/MENDITTZO-Backend/src/main/java/com/mendittzo/user/query/application/dto/UserQueryResponseDTO.java
+++ b/MENDITTZO-Backend/src/main/java/com/mendittzo/user/query/application/dto/UserQueryResponseDTO.java
@@ -5,8 +5,6 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
 
-import java.time.LocalDateTime;
-
 // 회원과 관련된 모든 정보에 대한 DTO
 // 다른 API 에서 회원의 일부 정보를 필요로 할 때 사용한다.
 @Getter

--- a/MENDITTZO-Backend/src/main/java/com/mendittzo/user/query/application/service/UserQueryService.java
+++ b/MENDITTZO-Backend/src/main/java/com/mendittzo/user/query/application/service/UserQueryService.java
@@ -17,7 +17,7 @@ public class UserQueryService {
     public UserQueryResponseDTO findUserInfo(Long userId) {
 
         User user = userQueryRepository.findById(userId)
-                .orElseThrow( () -> new CustomException(ErrorCode.NOT_FOUND_USER) );
+                .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_USER));
 
         return user.createQueryResponseDTO();
     }

--- a/MENDITTZO-Backend/src/main/resources/application.yml
+++ b/MENDITTZO-Backend/src/main/resources/application.yml
@@ -30,3 +30,5 @@ kakao:
 
 token:
   secret: ${token.secret}
+  access_token_expiration_time: ${token.access_token_expiration_time}
+  refresh_token_expiration_time: ${token.refresh_token_expiration_time}


### PR DESCRIPTION
카카오 소셜 로그인에 성공하면, access, refresh 토큰 생성을 클라이언트에게 넘겨주게 했습니다.

- DebookTokenDTO: 서버 -> 클라이언트에게 보내는 토큰
- TokenCreateRequestDTO: redis 적용 전 임시로 mariaDB에 저장하기 위한 DTO
