### PR TITLE
feat: 프론트에서 보낸 api 요청 헤더에서 토큰 꺼내서 읽기

### DIFF
--- a/MENDITTZO-Backend/src/main/java/com/mendittzo/security/filter/JwtFilter.java
+++ b/MENDITTZO-Backend/src/main/java/com/mendittzo/security/filter/JwtFilter.java
@@ -29,12 +29,12 @@ public class JwtFilter extends OncePerRequestFilter {
 
         // 요청 헤더에 담긴 토큰의 유효성 판별 및 인증 객체 저장
         String authorizationHeader = request.getHeader("Authorization");
-        log.info("Authorization header : {}", authorizationHeader);
+        log.info("Authorization 헤더:{}", authorizationHeader);
 
         if (authorizationHeader != null && authorizationHeader.startsWith("Bearer ")) {
 
             String token = authorizationHeader.substring(7);
-            log.info("토큰: {}", token);
+            log.info("토큰:{}", token);
 
             try {
                 // 유효한 토큰이면

--- a/MENDITTZO-Backend/src/main/java/com/mendittzo/security/service/userService.java
+++ b/MENDITTZO-Backend/src/main/java/com/mendittzo/security/service/userService.java
@@ -1,5 +1,6 @@
 package com.mendittzo.security.service;
 
+import com.mendittzo.security.util.CustomUserDetails;
 import com.mendittzo.user.command.domain.aggregate.User;
 import com.mendittzo.user.command.domain.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
@@ -16,12 +17,14 @@ public class userService implements UserDetailsService {
 
     public UserDetails loadUserByLoginId(Long loginId) {
 
+        // 인증 토큰에 담겨 넘어온 loginId 를 기준으로 DB 에서 해당 유저를 찾는다.
         User user = userRepository.findByLoginId(loginId);
+
         if(user == null) {
             throw new UsernameNotFoundException("해당 loginId로 사용자를 찾을 수 없습니다.");
         }
 
-        return new CustomUserDetails(user);
+        return new CustomUserDetails(user.getLoginId(), user.getUserId(), user.getStatus());
     }
 
     @Override

--- a/MENDITTZO-Backend/src/main/java/com/mendittzo/security/util/CustomUserDetails.java
+++ b/MENDITTZO-Backend/src/main/java/com/mendittzo/security/util/CustomUserDetails.java
@@ -1,5 +1,6 @@
-package com.mendittzo.security.service;
+package com.mendittzo.security.util;
 
+import com.mendittzo.user.command.domain.aggregate.Status;
 import com.mendittzo.user.command.domain.aggregate.User;
 import lombok.Getter;
 import org.springframework.security.core.GrantedAuthority;
@@ -8,13 +9,33 @@ import org.springframework.security.core.userdetails.UserDetails;
 import java.util.Collection;
 import java.util.List;
 
-@Getter
+//  UserDetails 에서 loginId 를 가져오기 위한 커스텀 UserDetails 클래스
+
 public class CustomUserDetails implements UserDetails {
 
-    private final User user;
+    // loginId 를 가져오는 메소드
+    private final Long loginId;
+    private final Long userId;
+    private final Status status;
+//    private final String username;  // UserDetails에서 사용하는 기본 필드
+//    private final String password;  // UserDetails에서 사용하는 기본 필드
 
-    public CustomUserDetails(User user) {
-        this.user = user;
+    public Long getLoginId() {
+        return loginId;
+    }
+
+    public Long getUserId() {
+        return userId;
+    }
+
+    public Status getStatus() {
+        return status;
+    }
+
+    public CustomUserDetails(Long loginId, Long userId, Status status) {
+        this.loginId = loginId;
+        this.userId = userId;
+        this.status = status;
     }
 
     @Override
@@ -29,7 +50,7 @@ public class CustomUserDetails implements UserDetails {
 
     @Override
     public String getUsername() {
-        return user.getNickname();
+        return "";
     }
 
     @Override

--- a/MENDITTZO-Backend/src/main/java/com/mendittzo/security/util/JwtUtil.java
+++ b/MENDITTZO-Backend/src/main/java/com/mendittzo/security/util/JwtUtil.java
@@ -106,6 +106,8 @@ public class JwtUtil {
 
     // 토큰 검증하는 메소드
     public boolean validateToken(String token) {
+
+        log.info("validateToken이 받는 토큰:{}", token);
         try {
             // 토큰 생성 시 사용한 키로 검증
             Jwts.parserBuilder().setSigningKey(secretKey).build().parseClaimsJws(token);
@@ -132,12 +134,14 @@ public class JwtUtil {
 
     // 토큰에서 Claims 추출하는 메소드
     public Claims parseClaims(String token) {
+        log.info("parseClaims가 받는 토큰:{}", token);
 
         return Jwts.parserBuilder().setSigningKey(secretKey).build().parseClaimsJws(token).getBody();
     }
 
     // 토큰에서 사용자의 소셜 로그인 고유 id 추출
     public Long getLoginId(String token) {
+        log.info("getLoginId가 받는 token:{}", token);
 
         return parseClaims(token).get("socialLoginId", Long.class);
     }
@@ -145,8 +149,10 @@ public class JwtUtil {
     // API 요청 헤더에 담긴 액세스 토큰으로 인증 객체(Authentication) 추출
     public Authentication getAuthentication(String token) {
 
+        log.info("getAuthentication이 받는 토큰:{}", token);
+
         UserDetails userDetails = userService.loadUserByLoginId(this.getLoginId(token));
 
-        return new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
+        return new UsernamePasswordAuthenticationToken(userDetails, "", userDetails.getAuthorities());
     }
 }

--- a/MENDITTZO-Backend/src/main/java/com/mendittzo/security/util/UserUtil.java
+++ b/MENDITTZO-Backend/src/main/java/com/mendittzo/security/util/UserUtil.java
@@ -1,0 +1,37 @@
+package com.mendittzo.security.util;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Component;
+
+@Component
+@Slf4j
+public class UserUtil {
+
+    private static JwtUtil jwtUtil;
+
+    @Autowired
+    public UserUtil(JwtUtil jwtUtil) {
+        UserUtil.jwtUtil = jwtUtil;
+    }
+
+    // 현재 로그인 한 사용자의 loginId 를 가져오는 메소드
+    public static Long getCurrentUserLoginId() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication != null && authentication.getPrincipal() instanceof UserDetails) {
+
+            // customUserDetails 에서 loginId 가져오기
+            CustomUserDetails userDetails = (CustomUserDetails) authentication.getPrincipal();
+
+            log.info("userDetails.getLoginId():" + userDetails.getLoginId());
+
+            return userDetails.getLoginId();
+        }
+        // 인증이 안 된 경우
+        return null;
+    }
+
+}

--- a/MENDITTZO-Backend/src/main/java/com/mendittzo/user/query/application/controller/UserQueryController.java
+++ b/MENDITTZO-Backend/src/main/java/com/mendittzo/user/query/application/controller/UserQueryController.java
@@ -1,6 +1,8 @@
 package com.mendittzo.user.query.application.controller;
 
+import com.mendittzo.common.exception.ErrorCode;
 import com.mendittzo.security.util.JwtUtil;
+import com.mendittzo.security.util.UserUtil;
 import com.mendittzo.user.query.application.dto.UserQueryResponseDTO;
 import com.mendittzo.user.query.application.service.UserQueryService;
 import lombok.RequiredArgsConstructor;
@@ -16,10 +18,14 @@ public class UserQueryController {
     private final JwtUtil jwtUtil;
 
     @GetMapping("/info")
-    public ResponseEntity<UserQueryResponseDTO> findUserInfo(@RequestHeader("Authorization") String accessToken) {
+    public ResponseEntity<UserQueryResponseDTO> findUserInfo() {
 
-        // 액세스 토큰에서 userId 추출
-        Long loginId = jwtUtil.getLoginId(accessToken);
+        // 인증 객체에서 loginId 꺼내기
+        Long loginId = UserUtil.getCurrentUserLoginId();
+
+        if (loginId == null) {
+            return ResponseEntity.status(401).build();
+        }
 
         UserQueryResponseDTO findUserInfo = userQueryService.findUserInfoByLoginId(loginId);
 


### PR DESCRIPTION
클라 -> 서버로 보낸 api 요청 헤더에서 accessToken 을 꺼낸 뒤,
인증 객체에 해당 토큰 저장해서 loginId 꺼내는 getCurrentLoginId 메소드를 만들어 두었습니다.

로그인 한 유저의 loginId(userId 아님! 카카오 고유 사용자 id를 의미)를 꺼내서 사용하시면 됩니다.